### PR TITLE
Moved createReadStream to scanStream function to prevent node crashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ scanner.scanFile(path, 3000, 1024 * 1024)
 
 ## scanner.scanDirectory(rootPath, [options])
 ```js
-let optins = {
+let options = {
     timeout: 5000,
     chunkSize: 64 * 1024,
     scanningFile: 10,
@@ -100,7 +100,7 @@ scanner.scanDirectory(rootPath, options)
 **Returns a promise, which will resovle with a object which contained the scan summary**
 
 - `rootPath (String)` - directory path, will be pass to path.normalize() first
-- `optinns (Object)`
+- `options (Object)`
   - `timeout (Number)` - use to set the socket's timeout option, default `5000`
   - `chunkSize (Number)` - size of the chunk, which will send to ClamAV server, default `64 * 1024`
   - `scanningFile (Number)` - the number of file will scan concurrently, should not be greater than the file table limit in node.js, default `10`
@@ -114,4 +114,4 @@ scanner.scanDirectory(rootPath, options)
 **Returns clamav version information**
 
 ## clamd.isCleanReply(reply)
-**Retuens true if the reply of a scan means OK, false if means infected**
+**Returns true if the reply of a scan means OK, false if means infected**

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function createScanner (host, port) {
    * @return {Promise}
    */
 
-  function scanStream (timeout, chunkSize) {
+  function scanStream (filePath, timeout, chunkSize) {
     if (typeof timeout !== 'number' || timeout < 0) timeout = 5000
 
     return new Promise(function (resolve, reject) {
@@ -127,7 +127,7 @@ function createScanner (host, port) {
     if (typeof timeout !== 'number' || timeout < 0) timeout = 5000
     if (typeof chunkSize !== 'number') chunkSize = 64 * 1024
 
-    return scanStream(timeout, timeout, chunkSize)
+    return scanStream(filePath, timeout, chunkSize)
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -35,17 +35,21 @@ function createScanner (host, port) {
 
   /**
    * scan a read stream
-   * @param {object} readStream
    * @param {number} [timeout = 5000] the socket's timeout option
+   * @param {number} [chunkSize = 64kb] size of the chunk, which send to Clamav server
    * @return {Promise}
    */
 
-  function scanStream (readStream, timeout) {
+  function scanStream (timeout, chunkSize) {
     if (typeof timeout !== 'number' || timeout < 0) timeout = 5000
 
     return new Promise(function (resolve, reject) {
       let readFinished = false
 
+      let readStream = fs.createReadStream(filePath, {
+        highWaterMark: chunkSize
+      })
+      .on('error', reject)
       const socket = net.createConnection({
         host,
         port
@@ -58,7 +62,6 @@ function createScanner (host, port) {
             readFinished = true
             readStream.destroy()
           })
-          .on('error', reject)
       })
 
       let replys = []
@@ -124,10 +127,7 @@ function createScanner (host, port) {
     if (typeof timeout !== 'number' || timeout < 0) timeout = 5000
     if (typeof chunkSize !== 'number') chunkSize = 64 * 1024
 
-    let s = fs.createReadStream(filePath, {
-      highWaterMark: chunkSize
-    })
-    return scanStream(s, timeout)
+    return scanStream(timeout, timeout, chunkSize)
   }
 
   /**


### PR DESCRIPTION
fs.createReadStream function crashed node if the passed file path is invalid to scanFile-function. This happens, because createReadStream is not [asyncronous function](https://stackoverflow.com/questions/30386768/is-createreadstream-asynchronous), and it is run concurrently with scanStream function promise. This means that if invalid file path is given as a parameter to scanFile function, it continues to scanStream function without first throwing the error from the invalid file path. This throws an error outside the promise and crashes node. My suggestion is to move createReadStream inside the promise and catch the error right after this. This handles the thrown error by createReadStream as a rejected promise and so it can be caught and dealt with.